### PR TITLE
Use typeface name in page title

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -9,10 +9,13 @@ angular.module('googleWebfontsHelperApp', [
     'cgBusy'
   ])
   .config(function($stateProvider, $urlRouterProvider, $locationProvider) {
-    
+
     $urlRouterProvider
       .otherwise('/fonts'); // default urls is /fonts
 
     $locationProvider.html5Mode(true);
 
+  })
+  .run(function($rootScope) {
+    $rootScope.APP_TITLE = 'Google Webfonts Helper'
   });

--- a/client/app/fonts/fonts.controller.js
+++ b/client/app/fonts/fonts.controller.js
@@ -80,6 +80,8 @@ angular.module('googleWebfontsHelperApp')
 
   $scope.loadingPromise = $http.get('/api/fonts/' + $stateParams.id + '?subsets=' + subSetString)
     .success(function(fontItem) {
+
+      // Prepend the name of the typeface to the document title
       window.document.title = fontItem.family + ' | ' + $rootScope.APP_TITLE;
       $scope.fontItem = fontItem;
 

--- a/client/app/fonts/fonts.controller.js
+++ b/client/app/fonts/fonts.controller.js
@@ -46,7 +46,7 @@ angular.module('googleWebfontsHelperApp')
 
   })
 
-.controller('FontsItemCtrl', function($scope, $stateParams, $http, $state, $timeout, $interval) {
+.controller('FontsItemCtrl', function($scope, $stateParams, $http, $state, $timeout, $interval, $rootScope) {
 
   var subSetString = $stateParams.subsets || '';
 
@@ -80,6 +80,7 @@ angular.module('googleWebfontsHelperApp')
 
   $scope.loadingPromise = $http.get('/api/fonts/' + $stateParams.id + '?subsets=' + subSetString)
     .success(function(fontItem) {
+      window.document.title = fontItem.family + ' | ' + $rootScope.APP_TITLE;
       $scope.fontItem = fontItem;
 
       $scope.downloadSubSetID = fontItem.storeID.replace(/_/g, ',');

--- a/client/app/fonts/fonts.html
+++ b/client/app/fonts/fonts.html
@@ -34,7 +34,7 @@
 
       <div class="col-lg-10 col-md-9 col-sm-9 col-xs-8">
         <!-- App name -->
-        <h4 class="page-header"><a href="/" ng-click="selectedItemID=''">google-webfonts-helper</a><br/><small>Get eot, ttf, svg, woff and woff2 files + CSS snippets</small></h4>
+        <h4 class="page-header"><a href="/" ng-click="selectedItemID=''">{{APP_TITLE}}</a><br/><small>Get eot, ttf, svg, woff and woff2 files + CSS snippets</small></h4>
         <!-- GH Stars -->
         <iframe id="githubCount" src="https://ghbtns.com/github-btn.html?user=majodev&repo=google-webfonts-helper&type=watch&count=true&size=large"
           allowtransparency="true" frameborder="0" scrolling="0" width="170px" height="30px"></iframe>
@@ -62,7 +62,7 @@
             <!-- Placeholder no item selected -->
             <header class="jumbotron masthead">
               <div class="inner">
-                <h1>google-webfonts-helper</h1>
+                <h1>{{APP_TITLE}}</h1>
                 <h2>A Hassle-Free Way to Self-Host Google Fonts</h2>
                 <h6>by <a href="http://mranftl.com" target="_blank">Mario Ranftl</a></h6>
                 <hr />

--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <base href="/">
     <meta name="google-site-verification" content="al_wEWN9QTMdH0LIzJpanPUiK1lrThiJVuQYDoyflJg" />
-    <title>google webfonts helper</title>
+    <title>Google Webfonts Helper</title>
     <meta name="description" content="A Hassle-Free Way to Self-Host Google Fonts. Get eot, ttf, svg, woff and woff2 files + CSS snippets!">
     <meta name="author" content="Mario Ranftl">
     <meta name="keywords" content="font, host, self-host, font-face, serve, zip, archive, css, woff, woff2, eot, ttf, svg, web fonts, google web fonts, google fonts, instructions, modern browsers, best support, font service">


### PR DESCRIPTION
## Summary
This PR:
- turns the name of the app from a slug into a proper title (`google-webfonts-helper` --> `Google Webfonts Helper`)
- the name of the selected typeface to the page title after the font data has been fetched. For example, the path `/fonts/abel` now yields a page titled `Abel | Google Webfonts Helper`.

## Screenshots

| Before                                                                                                                                         | After                                                                                                                                          |
|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| ![CleanShot 2023-05-09 at 20 46 20@2x](https://github.com/majodev/google-webfonts-helper/assets/13525251/397de525-be24-4b34-be0b-f727abd18988) | ![CleanShot 2023-05-09 at 20 47 36@2x](https://github.com/majodev/google-webfonts-helper/assets/13525251/7e37bc60-acb6-4b31-8953-381cc4ad6f58) |


## Related issues
Closes #169